### PR TITLE
v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ tf_hachef CHANGELOG
 
 This file is used to list changes made in each version of the tf_hachef Terraform plan.
 
+v0.2.7 (2016-09-20)
+-------------------
+- Updated chef-cookbook script to pin system cookbook to `0.11.0`: xhost-cookbooks/system#49
+- Update syntax; `template_file` resource is deprecated, updated to `data` source
+
 v0.2.6 (2016-08-11)
 -------------------
 - Updated root device to use gp2 on backends

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the requirements are extensive
   * Route53 internal and external zones
   * Uploaded to AWS a SSL certificate (wildcard preferred)
   * SSL certificate/key for created instance (local files to upload to instances)
-  * Terraform >= 0.6.14
+  * Terraform >= 0.7.3
 * Uses public IPs and public DNS
 * Creates default security group as follows:
   * Frontend:

--- a/files/chef-cookbooks.sh
+++ b/files/chef-cookbooks.sh
@@ -9,8 +9,10 @@ for DEP in chef_handler chef-ingredient ; do curl -sL https://supermarket.chef.i
 for DEP in chef-server chef-sugar       ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
 for DEP in compat_resource cron         ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
 for DEP in firewall hostsfile logrotate ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
-for DEP in packagecloud system yum      ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in packagecloud        yum      ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
 for DEP in yum-chef windows             ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+
+curl -sL https://supermarket.chef.io/cookbooks/system/versions/0.11.0/download | sudo tar xzC /var/chef/cookbooks
 
 sudo chown -R root:root /var/chef
 

--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ resource "null_resource" "chef-prep" {
   }
 }
 # Chef provisiong backend attributes_json and dna.json templating
-resource "template_file" "backend-attributes-json" {
+data "template_file" "backend-attributes-json" {
   count     = "${var.chef_backend["count"]}"
   template  = "${file("${path.module}/files/backend-attributes-json.tpl")}"
   vars {
@@ -276,7 +276,7 @@ resource "aws_instance" "chef-backends" {
   provisioner "remote-exec" {
     inline = [
       "cat > /tmp/dna.json <<EOF",
-      "${element(template_file.backend-attributes-json.*.rendered, count.index)}",
+      "${element(data.template_file.backend-attributes-json.*.rendered, count.index)}",
       "EOF",
     ]
   }
@@ -377,7 +377,7 @@ resource "aws_route53_record" "chef-backends-public" {
 #
 # Frontend: chef-server-core
 # Chef provisiong frontend attributes_json and dna.json templating
-resource "template_file" "frontend-attributes-json" {
+data "template_file" "frontend-attributes-json" {
   count      = "${var.chef_server["count"]}"
   template   = "${file("${path.module}/files/frontend-attributes-json.tpl")}"
   vars {
@@ -431,7 +431,7 @@ resource "aws_instance" "chef-frontends" {
   provisioner "remote-exec" {
     inline = [
       "cat > /tmp/dna.json <<EOF",
-      "${element(template_file.frontend-attributes-json.*.rendered, count.index)}",
+      "${element(data.template_file.frontend-attributes-json.*.rendered, count.index)}",
       "EOF",
     ]
   }


### PR DESCRIPTION
- Updated chef-cookbook script to pin system cookbook to `0.11.0`: xhost-cookbooks/system#49
- Update syntax; `template_file` resource is deprecated, updated to `data` source
