### PR TITLE
Fix typo for Chef license agreement notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ tf_hachef CHANGELOG
 
 This file is used to list changes made in each version of the tf_hachef Terraform plan.
 
+v0.2.10 (2017-02-23)
+--------------------
+- Fixed typo in a warning message relating to accepting Chef license
+
 v0.2.9 (2016-10-29)
 -------------------
 - Added ETCD tunable variables and implementation

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ per plan.
 ## Contributors
 
 * [Brian Menges](https://github.com/mengesb)
-
+* [Kevin Dickerson, Loom](https://loom.technology)
 
 ## Runtime sample
 

--- a/providers/aws/route53_ssl/files/chef_mlsa.bash
+++ b/providers/aws/route53_ssl/files/chef_mlsa.bash
@@ -4,12 +4,12 @@ case ${1,,} in
 
   1)     exit 0 ;;
 
-  false) echo "Please set acept_license = \"true\" in terraform.tfvars"
+  false) echo "Please set accept_license = \"true\" in terraform.tfvars"
          exit 1 ;;
 
-  0)     echo "Please set acept_license = \"true\" in terraform.tfvars"
+  0)     echo "Please set accept_license = \"true\" in terraform.tfvars"
          exit 1 ;;
 
-  *)     echo "Please set acept_license = \"true\" in terraform.tfvars"
+  *)     echo "Please set accept_license = \"true\" in terraform.tfvars"
          exit 1 ;;
 esac


### PR DESCRIPTION
This minor update fixes a few typos.